### PR TITLE
(feat) fix security group bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this module will be documented in this file.
 
+## [1.0.3] - 2022-07-05
+
+### Fix
+
+- bug `security_group` for network interface
+
 ## [1.0.2] - 2022-07-04
 
 ### Fix

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,3 @@
 locals {
   prefix = "${var.prefix}-${var.environment}-${var.name}"
-  security_group_ids = var.vpc_security_group_ids
 }

--- a/main.tf
+++ b/main.tf
@@ -164,7 +164,7 @@ resource "aws_launch_template" "this" {
       ipv6_address_count           = lookup(network_interfaces.value, "ipv6_address_count", null)
       network_interface_id         = lookup(network_interfaces.value, "network_interface_id", null)
       private_ip_address           = lookup(network_interfaces.value, "private_ip_address", null)
-      security_groups              = compact(concat(try(network_interfaces.value.security_groups, []), local.security_group_ids))
+      security_groups              = lookup(network_interfaces.value, "security_groups", null)
       subnet_id                    = lookup(network_interfaces.value, "subnet_id", null)
     }
   }


### PR DESCRIPTION
## [1.0.3] - 2022-07-05

### Fix

- bug `security_group` for network interface
